### PR TITLE
Use GIT dependencies for out-of-repository crates instead of paths

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ build = ["aom-sys/build"]
 
 [dependencies]
 aom-sys = { version = "0.1.0", path = "aom-sys" }
-av-data = { version = "0.1.0", path = "../rust-av/data" }
-av-codec = { version = "0.1.0", path = "../rust-av/codec", optional = true }
+av-data = { version = "0.1.0", git = "https://github.com/rust-av/rust-av" }
+av-codec = { version = "0.1.0", git = "https://github.com/rust-av/rust-av", optional = true }
 
 [workspace]
 members = ["aom-sys"]


### PR DESCRIPTION
https://github.com/rust-av/rust-av/issues/55