### PR TITLE
Bump bindgen to 0.48

### DIFF
--- a/aom-sys/Cargo.toml
+++ b/aom-sys/Cargo.toml
@@ -15,7 +15,7 @@ aom = "0.1.0"
 build_sources = []
 
 [build-dependencies]
-bindgen = "0.47.2"
+bindgen = "0.48.0"
 metadeps = "1.1.2"
 
 [dependencies]


### PR DESCRIPTION
Tested in Fedora Rawhide.
https://copr.fedorainfracloud.org/coprs/eclipseo/rav1e/package/rust-aom-sys/