### PR TITLE
aom-sys: blacklist max_align_t in bindgen

### DIFF
--- a/aom-sys/build.rs
+++ b/aom-sys/build.rs
@@ -18,6 +18,7 @@ fn main() {
 
     let mut builder = bindgen::builder()
         .header("data/aom.h")
+        .blacklist_type("max_align_t")
         .size_t_is_usize(true)
         .default_enum_style(bindgen::EnumVariation::ModuleConsts);
 


### PR DESCRIPTION
The automatic test for `max_align_t` fails on i686-unknown-linux-gnu:

    ---- aom::bindgen_test_layout_max_align_t stdout ----
    thread 'aom::bindgen_test_layout_max_align_t' panicked at 'assertion
    failed: `(left == right)`
      left: `16`,
       right: `24`: Size of: max_align_t',
       [...]/build/aom-sys-784fb7e39b5bf92c/out/aom.rs:277:5

But this type isn't needed anyway, so we can just blacklist it like
other rust-av crates already do.